### PR TITLE
`resolve_constant_pool()` needs only one pass

### DIFF
--- a/src/constant_pool.rs
+++ b/src/constant_pool.rs
@@ -30,13 +30,6 @@ impl<'a> ConstantPoolRef<'a> {
         }
     }
 
-    fn is_resolved(&self) -> bool {
-        match self {
-            ConstantPoolRef::Unresolved(_) => false,
-            ConstantPoolRef::Resolved(_) => true,
-        }
-    }
-
     fn get(&self) -> &Rc<ConstantPoolEntry<'a>> {
         match self {
             ConstantPoolRef::Unresolved(_) => panic!("Called get on a unresolved ConstantPoolRef"),
@@ -143,24 +136,6 @@ impl<'a> ConstantPoolEntry<'a> {
             ConstantPoolEntry::ModuleInfo(x) => x.resolve(my_index, pool),
             ConstantPoolEntry::PackageInfo(x) => x.resolve(my_index, pool),
             _ => Ok(true),
-        }
-    }
-
-    fn is_resolved(&self) -> bool {
-        match self {
-            ConstantPoolEntry::ClassInfo(x) => x.borrow().is_resolved(),
-            ConstantPoolEntry::String(x) => x.borrow().is_resolved(),
-            ConstantPoolEntry::FieldRef(x, y) => x.borrow().is_resolved() && y.borrow().is_resolved(),
-            ConstantPoolEntry::MethodRef(x, y) => x.borrow().is_resolved() && y.borrow().is_resolved(),
-            ConstantPoolEntry::InterfaceMethodRef(x, y) => x.borrow().is_resolved() && y.borrow().is_resolved(),
-            ConstantPoolEntry::NameAndType(x, y) => x.borrow().is_resolved() && y.borrow().is_resolved(),
-            ConstantPoolEntry::MethodHandle(_, y) => y.borrow().is_resolved(),
-            ConstantPoolEntry::MethodType(x) => x.borrow().is_resolved(),
-            ConstantPoolEntry::Dynamic(_, y) => y.borrow().is_resolved(),
-            ConstantPoolEntry::InvokeDynamic(_, y) => y.borrow().is_resolved(),
-            ConstantPoolEntry::ModuleInfo(x) => x.borrow().is_resolved(),
-            ConstantPoolEntry::PackageInfo(x) => x.borrow().is_resolved(),
-            _ => true,
         }
     }
 

--- a/src/constant_pool.rs
+++ b/src/constant_pool.rs
@@ -491,18 +491,9 @@ fn read_constant_package<'a>(bytes: &'a [u8], ix: &mut usize) -> Result<Constant
 }
 
 fn resolve_constant_pool<'a>(constant_pool: &[Rc<ConstantPoolEntry<'a>>]) -> Result<(), ParseError> {
-    let mut resolved_count = 0;
-    while resolved_count < constant_pool.len() {
-        let mut count = 0;
-        for (i, cp_entry) in constant_pool.iter().enumerate() {
-            if cp_entry.resolve(i, &constant_pool)? {
-                count += 1;
-            }
-        }
-        if count == resolved_count {
-            fail!("Unable to resolve all constant pool entries");
-        }
-        resolved_count = count;
+    for (i, cp_entry) in constant_pool.iter().enumerate() {
+        let resolved = cp_entry.resolve(i, &constant_pool)?;
+	assert!(resolved); // resolve() now always returns true
     }
     Ok(())
 }

--- a/src/constant_pool.rs
+++ b/src/constant_pool.rs
@@ -23,9 +23,6 @@ impl<'a> ConstantPoolRef<'a> {
                 if target >= pool.len() {
                     fail!("Constant pool entry at index {} references out-of-bounds index {}", my_index, target);
                 }
-                if !pool[target].is_resolved() {
-                    return Ok(false);
-                }
                 *self = ConstantPoolRef::Resolved(pool[target].clone());
                 Ok(true)
             }


### PR DESCRIPTION
`resolve_constant_pool()` currently has to make several passes because `ConstantPoolRef::resolve()` does not resolve to constant pool entries that themselves are not resolved yet. However, this limitation seems unnecessary.

* The first commit changes `ConstantPoolRef::resolve()` to resolve even to a constant pool entry that is not resolved yet.
* The second commit changes `resolve_constant_pool()` to make a single pass.
* The remaining commits are some simplifications resulting from the first commits.

Further simplifications might be possible, but I'd like to get your feedback first.