### PR TITLE
Address some Clippy warnings

### DIFF
--- a/src/attributes.rs
+++ b/src/attributes.rs
@@ -451,7 +451,7 @@ fn read_innerclasses_data<'a>(bytes: &'a [u8], ix: &mut usize, pool: &[Rc<Consta
     Ok(innerclasses)
 }
 
-fn read_linenumber_data<'a>(bytes: &'a [u8], ix: &mut usize) -> Result<Vec<LineNumberEntry>, ParseError> {
+fn read_linenumber_data(bytes: &[u8], ix: &mut usize) -> Result<Vec<LineNumberEntry>, ParseError> {
     let count = read_u2(bytes, ix)?;
     let mut linenumbers = Vec::with_capacity(count.into());
     for _i in 0..count {

--- a/src/constant_pool.rs
+++ b/src/constant_pool.rs
@@ -68,25 +68,25 @@ pub enum ReferenceKind {
 
 bitflags! {
     pub(crate) struct ConstantPoolEntryTypes: u32 {
-        const ZERO = 0x00000001;
-        const UTF8 = 0x00000002;
-        const INTEGER = 0x00000004;
-        const FLOAT = 0x00000008;
-        const LONG = 0x00000010;
-        const DOUBLE = 0x00000020;
-        const CLASS_INFO = 0x00000040;
-        const STRING = 0x00000080;
-        const FIELD_REF = 0x00000100;
-        const METHOD_REF = 0x00000200;
-        const INTERFACE_METHOD_REF = 0x00000400;
-        const NAME_AND_TYPE = 0x00000800;
-        const METHOD_HANDLE = 0x00001000;
-        const METHOD_TYPE = 0x00002000;
-        const DYNAMIC = 0x00004000;
-        const INVOKE_DYNAMIC = 0x00008000;
-        const MODULE_INFO = 0x00010000;
-        const PACKAGE_INFO = 0x00020000;
-        const UNUSED = 0x00040000;
+        const ZERO = 0x0000_0001;
+        const UTF8 = 0x0000_0002;
+        const INTEGER = 0x0000_0004;
+        const FLOAT = 0x0000_0008;
+        const LONG = 0x0000_0010;
+        const DOUBLE = 0x0000_0020;
+        const CLASS_INFO = 0x0000_0040;
+        const STRING = 0x0000_0080;
+        const FIELD_REF = 0x0000_0100;
+        const METHOD_REF = 0x0000_0200;
+        const INTERFACE_METHOD_REF = 0x0000_0400;
+        const NAME_AND_TYPE = 0x0000_0800;
+        const METHOD_HANDLE = 0x0000_1000;
+        const METHOD_TYPE = 0x0000_2000;
+        const DYNAMIC = 0x0000_4000;
+        const INVOKE_DYNAMIC = 0x0000_8000;
+        const MODULE_INFO = 0x0001_0000;
+        const PACKAGE_INFO = 0x0002_0000;
+        const UNUSED = 0x0004_0000;
 
         const NEW_METHOD_REFS = Self::METHOD_REF.bits() | Self::INTERFACE_METHOD_REF.bits();
         const CONSTANTS = Self::INTEGER.bits() | Self::FLOAT.bits() | Self::LONG.bits() | Self::DOUBLE.bits() | Self::STRING.bits();

--- a/src/constant_pool.rs
+++ b/src/constant_pool.rs
@@ -305,7 +305,7 @@ impl<'a> ConstantPoolEntry<'a> {
                 y.borrow().get().validate_method_descriptor()
             }
             ConstantPoolEntry::Utf8(x) => {
-                if is_method_descriptor(&x) {
+                if is_method_descriptor(x) {
                     Ok(true)
                 } else {
                     fail!("Invalid method descriptor")
@@ -467,7 +467,7 @@ fn read_constant_package<'a>(bytes: &'a [u8], ix: &mut usize) -> Result<Constant
 
 fn resolve_constant_pool(constant_pool: &[Rc<ConstantPoolEntry>]) -> Result<(), ParseError> {
     for (i, cp_entry) in constant_pool.iter().enumerate() {
-        cp_entry.resolve(i, &constant_pool)?;
+        cp_entry.resolve(i, constant_pool)?;
     }
     Ok(())
 }

--- a/src/constant_pool.rs
+++ b/src/constant_pool.rs
@@ -465,14 +465,14 @@ fn read_constant_package<'a>(bytes: &'a [u8], ix: &mut usize) -> Result<Constant
     Ok(ConstantPoolEntry::PackageInfo(name_ref))
 }
 
-fn resolve_constant_pool<'a>(constant_pool: &[Rc<ConstantPoolEntry<'a>>]) -> Result<(), ParseError> {
+fn resolve_constant_pool(constant_pool: &[Rc<ConstantPoolEntry>]) -> Result<(), ParseError> {
     for (i, cp_entry) in constant_pool.iter().enumerate() {
         cp_entry.resolve(i, &constant_pool)?;
     }
     Ok(())
 }
 
-fn validate_constant_pool<'a>(constant_pool: &[Rc<ConstantPoolEntry<'a>>], major_version: u16) -> Result<(), ParseError> {
+fn validate_constant_pool(constant_pool: &[Rc<ConstantPoolEntry>], major_version: u16) -> Result<(), ParseError> {
     for (i, cp_entry) in constant_pool.iter().enumerate() {
         let valid = cp_entry.validate(major_version).map_err(|e| err!(e, "constant pool entry {}", i))?;
         assert!(valid); // validate functions should never return Ok(false)

--- a/src/constant_pool.rs
+++ b/src/constant_pool.rs
@@ -372,6 +372,7 @@ fn read_constant_utf8<'a>(bytes: &'a [u8], ix: &mut usize) -> Result<ConstantPoo
 }
 
 fn read_constant_integer<'a>(bytes: &'a [u8], ix: &mut usize) -> Result<ConstantPoolEntry<'a>, ParseError> {
+    #![allow(clippy::cast_possible_wrap)] // Wrapping is allowed and desired.
     Ok(ConstantPoolEntry::Integer(read_u4(bytes, ix)? as i32))
 }
 
@@ -380,6 +381,7 @@ fn read_constant_float<'a>(bytes: &'a [u8], ix: &mut usize) -> Result<ConstantPo
 }
 
 fn read_constant_long<'a>(bytes: &'a [u8], ix: &mut usize) -> Result<ConstantPoolEntry<'a>, ParseError> {
+    #![allow(clippy::cast_possible_wrap)] // Wrapping is allowed and desired.
     Ok(ConstantPoolEntry::Long(read_u8(bytes, ix)? as i64))
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -48,7 +48,7 @@ pub struct ParseError {
 impl ParseError {
     pub(crate) fn new(msg: String) -> Self {
         ParseError {
-            msg: msg,
+            msg,
             contexts: Vec::new(),
         }
     }
@@ -58,7 +58,7 @@ impl ParseError {
         contexts.push(context);
         ParseError {
             msg: base.msg,
-            contexts: contexts,
+            contexts,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -315,8 +315,8 @@ pub fn parse_class<'a>(raw_bytes: &'a [u8]) -> Result<ClassFile<'a>, ParseError>
     }
 
     if is_module {
-        if super_class.is_some() {
-            fail!("Found non-empty super_class {}; expected none for module", super_class.unwrap());
+        if let Some(super_class) = super_class {
+            fail!("Found non-empty super_class {}; expected none for module", super_class);
         }
         if !interfaces.is_empty() {
             fail!("Found {} interfaces; expected 0 for module", interfaces.len());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -286,7 +286,7 @@ impl<'a> ClassFile<'a> {
 
 pub fn parse_class<'a>(raw_bytes: &'a [u8]) -> Result<ClassFile<'a>, ParseError> {
     let mut ix = 0;
-    if read_u4(raw_bytes, &mut ix)? != 0xCAFEBABE {
+    if read_u4(raw_bytes, &mut ix)? != 0xCAFE_BABE {
         fail!("Unexpected magic header");
     }
     let minor_version = read_u2(raw_bytes, &mut ix)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -279,6 +279,7 @@ pub struct ClassFile<'a> {
 }
 
 impl<'a> ClassFile<'a> {
+    #[must_use]
     pub fn constantpool_iter(&'a self) -> ConstantPoolIter<'a> {
         ConstantPoolIter::new(&self.constant_pool)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -318,13 +318,13 @@ pub fn parse_class<'a>(raw_bytes: &'a [u8]) -> Result<ClassFile<'a>, ParseError>
         if super_class.is_some() {
             fail!("Found non-empty super_class {}; expected none for module", super_class.unwrap());
         }
-        if interfaces.len() != 0 {
+        if !interfaces.is_empty() {
             fail!("Found {} interfaces; expected 0 for module", interfaces.len());
         }
-        if fields.len() != 0 {
+        if !fields.is_empty() {
             fail!("Found {} fields; expected 0 for module", fields.len());
         }
-        if methods.len() != 0 {
+        if !methods.is_empty() {
             fail!("Found {} methods; expected 0 for module", methods.len());
         }
     }

--- a/src/names.rs
+++ b/src/names.rs
@@ -21,10 +21,7 @@ pub(crate) fn is_unqualified_name(name: &str, allow_init: bool, allow_clinit: bo
 }
 
 fn is_valid_unqualified_char(c: char) -> bool {
-    match c {
-        '.' | ';' | '[' | '/' | '<' | '>' => false,
-        _ => true,
-    }
+    !matches!(c, '.' | ';' | '[' | '/' | '<' | '>')
 }
 
 pub(crate) fn is_module_name(name: &str) -> bool {

--- a/src/names.rs
+++ b/src/names.rs
@@ -17,12 +17,7 @@ pub(crate) fn is_unqualified_name(name: &str, allow_init: bool, allow_clinit: bo
         Some(x) if !is_valid_unqualified_char(x) => return false,
         Some(_) => (),
     };
-    for x in chars {
-        if !is_valid_unqualified_char(x) {
-            return false;
-        }
-    }
-    true
+    chars.all(is_valid_unqualified_char)
 }
 
 fn is_valid_unqualified_char(c: char) -> bool {

--- a/src/names.rs
+++ b/src/names.rs
@@ -17,7 +17,7 @@ pub(crate) fn is_unqualified_name(name: &str, allow_init: bool, allow_clinit: bo
         Some(x) if !is_valid_unqualified_char(x) => return false,
         Some(_) => (),
     };
-    while let Some(x) = chars.next() {
+    for x in chars {
         if !is_valid_unqualified_char(x) {
             return false;
         }
@@ -54,7 +54,7 @@ pub(crate) fn is_module_name(name: &str) -> bool {
 /// Returns Some(';') for an unqualified segment followed by ;
 fn consume_unqualified_segment(chars: &mut Chars) -> Option<char> {
     let mut first = true;
-    while let Some(c) = chars.next() {
+    for c in chars {
         match c {
             '/' if first => return None,
             ';' if first => return None,


### PR DESCRIPTION
I tried to make only non-invasive and hopefully non-controversial changes. Some Clippy warnings remain.

One commit per warning, which should make it easy to review and I can easily drop any commits if you don't agree with some of them.

Details of each Clippy warning can be found by searching the warning name from the commit [here](https://rust-lang.github.io/rust-clippy/master/).
