### PR TITLE
Fix validate panic

### DIFF
--- a/src/constant_pool.rs
+++ b/src/constant_pool.rs
@@ -245,6 +245,16 @@ impl<'a> ConstantPoolEntry<'a> {
         }
     }
 
+    /// Returns &str if self if Utf8. Returns parse error otherwise.
+    /// TODO currently panics if self is Utf8Bytes.
+    fn str(&self) -> Result<&str, ParseError> {
+        match self {
+            ConstantPoolEntry::Utf8(x) => Ok(x),
+            ConstantPoolEntry::Utf8Bytes(_) => panic!("Attempting to get utf-8 data from non-utf8 constant pool entry!"),
+            _ => fail!("Unexpected constant pool reference type")
+        }
+    }
+
     fn validate_classinfo_name(&self) -> Result<bool, ParseError> {
         match self {
             ConstantPoolEntry::Utf8(x) => {

--- a/src/constant_pool.rs
+++ b/src/constant_pool.rs
@@ -868,3 +868,6 @@ impl<'a> Iterator for ConstantPoolIter<'a> {
         None
     }
 }
+
+#[cfg(test)]
+mod tests;

--- a/src/constant_pool.rs
+++ b/src/constant_pool.rs
@@ -256,55 +256,36 @@ impl<'a> ConstantPoolEntry<'a> {
     }
 
     fn validate_classinfo_name(&self) -> Result<bool, ParseError> {
-        match self {
-            ConstantPoolEntry::Utf8(x) => {
-                // Per 4.4.1, classinfo names are allowed to be array descriptors too. This happens in the java 16 modules file.
-                if is_binary_name(x) || is_array_descriptor(x) {
-                    Ok(true)
-                } else {
-                    fail!("Invalid binary name")
-                }
-            }
-            _ => panic!("Attempting to get utf-8 data from non-utf8 constant pool entry!"),
+        let x = self.str()?;
+        // Per 4.4.1, classinfo names are allowed to be array descriptors too. This happens in the java 16 modules file.
+        if is_binary_name(x) || is_array_descriptor(x) {
+            Ok(true)
+        } else {
+            fail!("Invalid binary name")
         }
     }
 
     fn validate_binary_name(&self) -> Result<bool, ParseError> {
-        match self {
-            ConstantPoolEntry::Utf8(x) => {
-                if is_binary_name(x) {
-                    Ok(true)
-                } else {
-                    fail!("Invalid binary name")
-                }
-            }
-            _ => panic!("Attempting to get utf-8 data from non-utf8 constant pool entry!"),
+        if is_binary_name(self.str()?) {
+            Ok(true)
+        } else {
+            fail!("Invalid binary name")
         }
     }
 
     fn validate_unqualified_name(&self) -> Result<bool, ParseError> {
-        match self {
-            ConstantPoolEntry::Utf8(x) => {
-                if is_unqualified_name(x, true, false) {
-                    Ok(true)
-                } else {
-                    fail!("Invalid unqualified name")
-                }
-            }
-            _ => panic!("Attempting to get utf-8 data from non-utf8 constant pool entry!"),
+        if is_unqualified_name(self.str()?, true, false) {
+            Ok(true)
+        } else {
+            fail!("Invalid unqualified name")
         }
     }
 
     fn validate_module_name(&self) -> Result<bool, ParseError> {
-        match self {
-            ConstantPoolEntry::Utf8(x) => {
-                if is_module_name(x) {
-                    Ok(true)
-                } else {
-                    fail!("Invalid module name")
-                }
-            }
-            _ => panic!("Attempting to get utf-8 data from non-utf8 constant pool entry!"),
+        if is_module_name(self.str()?) {
+            Ok(true)
+        } else {
+            fail!("Invalid module name")
         }
     }
 
@@ -316,7 +297,7 @@ impl<'a> ConstantPoolEntry<'a> {
                 // points to a later entry in the constant pool that hasn't been validated yet.
                 // assert on the bool because we should never get Ok(false).
                 assert!(y.ensure_type(ConstantPoolEntryTypes::UTF8)?);
-                if is_field_descriptor(&y.borrow().get().utf8()) {
+                if is_field_descriptor(&y.borrow().get().str()?) {
                     Ok(true)
                 } else {
                     fail!("Invalid field descriptor")
@@ -336,14 +317,13 @@ impl<'a> ConstantPoolEntry<'a> {
                 assert!(y.ensure_type(ConstantPoolEntryTypes::UTF8)?);
                 y.borrow().get().validate_method_descriptor()
             }
-            ConstantPoolEntry::Utf8(x) => {
-                if is_method_descriptor(x) {
+            _ => {
+                if is_method_descriptor(self.str()?) {
                     Ok(true)
                 } else {
                     fail!("Invalid method descriptor")
                 }
             }
-            _ => panic!("Attempting to get descriptor from non-NameAndType constant pool entry!"),
         }
     }
 

--- a/src/constant_pool.rs
+++ b/src/constant_pool.rs
@@ -246,11 +246,12 @@ impl<'a> ConstantPoolEntry<'a> {
     }
 
     /// Returns &str if self if Utf8. Returns parse error otherwise.
-    /// TODO currently panics if self is Utf8Bytes.
+    /// The parse error will have a special message if self is Utf8Bytes
+    /// because such an odd case might be difficult to debug otherwise.
     fn str(&self) -> Result<&str, ParseError> {
         match self {
             ConstantPoolEntry::Utf8(x) => Ok(x),
-            ConstantPoolEntry::Utf8Bytes(_) => panic!("Attempting to get utf-8 data from non-utf8 constant pool entry!"),
+            ConstantPoolEntry::Utf8Bytes(_) => fail!("Attempting to get utf-8 data from non-utf8 constant pool entry!"),
             _ => fail!("Unexpected constant pool reference type")
         }
     }

--- a/src/constant_pool/tests.rs
+++ b/src/constant_pool/tests.rs
@@ -1,0 +1,521 @@
+use super::*;
+use ConstantPoolEntry::*;
+
+macro_rules! assert_validate_passes {
+    ($entry:expr) => {
+        assert_eq!($entry.validate(0), Ok(true));
+    };
+    ($version:literal, $entry:expr) => {
+        assert_eq!($entry.validate($version), Ok(true));
+    };
+}
+
+macro_rules! assert_validate_fails {
+    ($entry:expr, $message:literal) => {
+        assert_eq!(
+            $entry.validate(0),
+            Err(ParseError::new($message.to_string()))
+        );
+    };
+    ($version:literal, $entry:expr, $message:literal) => {
+        assert_eq!(
+            $entry.validate($version),
+            Err(ParseError::new($message.to_string()))
+        );
+    };
+}
+
+// Temporarily capture existing suboptimal behavior. After
+// https://github.com/staktrace/cafebabe/issues/7
+// is fixed, all calls will be replaced with calls to assert_validate_fails
+// and this macro will be removed.
+macro_rules! assert_validate_panics {
+    ($entry:expr) => {
+        let result = std::panic::catch_unwind(|| {
+            let _ = $entry.validate(0);
+        });
+        assert!(result.is_err());
+    };
+}
+
+// Helper for creating the smart pointer types (RefCell, ConstantPoolRef,
+// Rc) required to nest ConstantPoolEntry instances.
+fn wrap(entry: ConstantPoolEntry) -> RefCell<ConstantPoolRef> {
+    RefCell::new(ConstantPoolRef::Resolved(Rc::new(entry)))
+}
+
+#[test]
+fn test_validate_trivial() {
+    assert_validate_passes!(Zero);
+    assert_validate_passes!(Utf8(Cow::from("some UTF-8")));
+    assert_validate_passes!(Utf8Bytes(&[]));
+    assert_validate_passes!(Integer(1));
+    assert_validate_passes!(Float(2.0));
+    assert_validate_passes!(Long(3));
+    assert_validate_passes!(Double(4.0));
+    assert_validate_passes!(Unused);
+}
+
+#[test]
+fn test_validate_class_info() {
+    assert_validate_passes!(ClassInfo(wrap(Utf8(Cow::from("some/package/Class")))));
+    assert_validate_passes!(ClassInfo(wrap(Utf8(Cow::from("[Lsome/package/Class;")))));
+
+    assert_validate_fails!(ClassInfo(wrap(Utf8(Cow::from("")))), "Invalid binary name");
+    assert_validate_panics!(ClassInfo(wrap(Utf8Bytes(&[]))));
+    assert_validate_fails!(
+        ClassInfo(wrap(Zero)),
+        "Unexpected constant pool reference type"
+    );
+}
+
+#[test]
+fn test_validate_string() {
+    assert_validate_passes!(String(wrap(Utf8(Cow::from("some UTF-8")))));
+    assert_validate_passes!(String(wrap(Utf8Bytes(&[]))));
+
+    assert_validate_fails!(
+        String(wrap(Zero)),
+        "Unexpected constant pool reference type"
+    );
+}
+
+#[test]
+fn test_validate_field_ref() {
+    assert_validate_passes!(FieldRef(
+        wrap(ClassInfo(wrap(Utf8(Cow::from("some/package/Class"))))),
+        wrap(NameAndType(
+            wrap(Utf8(Cow::from("someField"))),
+            wrap(Utf8(Cow::from("I"))),
+        )),
+    ));
+
+    assert_validate_fails!(
+        FieldRef(
+            wrap(Zero),
+            wrap(NameAndType(
+                wrap(Utf8(Cow::from("someField"))),
+                wrap(Utf8(Cow::from("I"))),
+            )),
+        ),
+        "Unexpected constant pool reference type"
+    );
+    assert_validate_fails!(
+        FieldRef(
+            wrap(ClassInfo(wrap(Utf8(Cow::from("some/package/Class"))))),
+            wrap(Zero),
+        ),
+        "Unexpected constant pool reference type"
+    );
+    assert_validate_fails!(
+        FieldRef(
+            wrap(ClassInfo(wrap(Utf8(Cow::from("some/package/Class"))))),
+            wrap(NameAndType(
+                wrap(Utf8(Cow::from("someField"))),
+                wrap(Utf8(Cow::from(""))),
+            )),
+        ),
+        "Invalid field descriptor"
+    );
+    assert_validate_panics!(
+        FieldRef(
+            wrap(ClassInfo(wrap(Utf8(Cow::from("some/package/Class"))))),
+            wrap(NameAndType(
+                wrap(Utf8(Cow::from("someField"))),
+                wrap(Utf8Bytes(&[])),
+            )),
+        )
+    );
+    assert_validate_fails!(
+        FieldRef(
+            wrap(ClassInfo(wrap(Utf8(Cow::from("some/package/Class"))))),
+            wrap(NameAndType(wrap(Utf8(Cow::from("someField"))), wrap(Zero))),
+        ),
+        "Unexpected constant pool reference type"
+    );
+}
+
+#[test]
+fn test_validate_method_ref() {
+    assert_validate_passes!(MethodRef(
+        wrap(ClassInfo(wrap(Utf8(Cow::from("some/package/Class"))))),
+        wrap(NameAndType(
+            wrap(Utf8(Cow::from("someMethod"))),
+            wrap(Utf8(Cow::from("()V"))),
+        )),
+    ));
+
+    assert_validate_fails!(
+        MethodRef(
+            wrap(Zero),
+            wrap(NameAndType(
+                wrap(Utf8(Cow::from("someMethod"))),
+                wrap(Utf8(Cow::from("()V"))),
+            )),
+        ),
+        "Unexpected constant pool reference type"
+    );
+    assert_validate_fails!(
+        MethodRef(
+            wrap(ClassInfo(wrap(Utf8(Cow::from("some/package/Class"))))),
+            wrap(Zero),
+        ),
+        "Unexpected constant pool reference type"
+    );
+    assert_validate_fails!(
+        MethodRef(
+            wrap(ClassInfo(wrap(Utf8(Cow::from("some/package/Class"))))),
+            wrap(NameAndType(
+                wrap(Utf8(Cow::from("someMethod"))),
+                wrap(Utf8(Cow::from(""))),
+            )),
+        ),
+        "Invalid method descriptor"
+    );
+    assert_validate_panics!(
+        MethodRef(
+            wrap(ClassInfo(wrap(Utf8(Cow::from("some/package/Class"))))),
+            wrap(NameAndType(
+                wrap(Utf8(Cow::from("someMethod"))),
+                wrap(Utf8Bytes(&[])),
+            )),
+        )
+    );
+    assert_validate_fails!(
+        MethodRef(
+            wrap(ClassInfo(wrap(Utf8(Cow::from("some/package/Class"))))),
+            wrap(NameAndType(wrap(Utf8(Cow::from("someMethod"))), wrap(Zero))),
+        ),
+        "Unexpected constant pool reference type"
+    );
+}
+
+#[test]
+fn test_validate_interface_method_ref() {
+    assert_validate_passes!(InterfaceMethodRef(
+        wrap(ClassInfo(wrap(Utf8(Cow::from("some/package/Class"))))),
+        wrap(NameAndType(
+            wrap(Utf8(Cow::from("someMethod"))),
+            wrap(Utf8(Cow::from("()V"))),
+        )),
+    ));
+
+    assert_validate_fails!(
+        InterfaceMethodRef(
+            wrap(Zero),
+            wrap(NameAndType(
+                wrap(Utf8(Cow::from("someMethod"))),
+                wrap(Utf8(Cow::from("()V"))),
+            )),
+        ),
+        "Unexpected constant pool reference type"
+    );
+    assert_validate_fails!(
+        InterfaceMethodRef(
+            wrap(ClassInfo(wrap(Utf8(Cow::from("some/package/Class"))))),
+            wrap(Zero),
+        ),
+        "Unexpected constant pool reference type"
+    );
+    assert_validate_fails!(
+        InterfaceMethodRef(
+            wrap(ClassInfo(wrap(Utf8(Cow::from("some/package/Class"))))),
+            wrap(NameAndType(
+                wrap(Utf8(Cow::from("someMethod"))),
+                wrap(Utf8(Cow::from(""))),
+            )),
+        ),
+        "Invalid method descriptor"
+    );
+    assert_validate_panics!(
+        InterfaceMethodRef(
+            wrap(ClassInfo(wrap(Utf8(Cow::from("some/package/Class"))))),
+            wrap(NameAndType(
+                wrap(Utf8(Cow::from("someMethod"))),
+                wrap(Utf8Bytes(&[])),
+            )),
+        )
+    );
+    assert_validate_fails!(
+        InterfaceMethodRef(
+            wrap(ClassInfo(wrap(Utf8(Cow::from("some/package/Class"))))),
+            wrap(NameAndType(wrap(Utf8(Cow::from("someMethod"))), wrap(Zero))),
+        ),
+        "Unexpected constant pool reference type"
+    );
+}
+
+#[test]
+fn test_validate_name_and_type() {
+    assert_validate_passes!(NameAndType(
+        wrap(Utf8(Cow::from("someUnqualifiedName"))),
+        wrap(Utf8(Cow::from("anything goes"))),
+    ));
+    assert_validate_passes!(NameAndType(
+        wrap(Utf8(Cow::from("someUnqualifiedName"))),
+        wrap(Utf8Bytes(&[])),
+    ));
+
+    assert_validate_fails!(
+        NameAndType(
+            wrap(Utf8(Cow::from(""))),
+            wrap(Utf8(Cow::from("anything goes"))),
+        ),
+        "Invalid unqualified name"
+    );
+    assert_validate_fails!(
+        NameAndType(wrap(Zero), wrap(Utf8(Cow::from("anything goes"))),),
+        "Unexpected constant pool reference type"
+    );
+    assert_validate_panics!(NameAndType(
+        wrap(Utf8Bytes(&[])),
+        wrap(Utf8(Cow::from("anything goes"))),
+    ));
+    assert_validate_fails!(
+        NameAndType(wrap(Utf8(Cow::from("someUnqualifiedName"))), wrap(Zero)),
+        "Unexpected constant pool reference type"
+    );
+}
+
+#[test]
+fn test_validate_method_handle() {
+    use ReferenceKind::*;
+
+    for kind in [GetField, GetStatic, PutField, PutStatic] {
+        assert_validate_passes!(MethodHandle(
+            kind,
+            wrap(FieldRef(
+                wrap(ClassInfo(wrap(Utf8(Cow::from("some/package/Class"))))),
+                wrap(NameAndType(
+                    wrap(Utf8(Cow::from("someField"))),
+                    wrap(Utf8(Cow::from("I"))),
+                )),
+            ))
+        ));
+
+        assert_validate_fails!(
+            MethodHandle(kind, wrap(Zero)),
+            "Unexpected constant pool reference type"
+        );
+    }
+
+    for kind in [InvokeVirtual, NewInvokeSpecial] {
+        assert_validate_passes!(MethodHandle(
+            kind,
+            wrap(MethodRef(
+                wrap(ClassInfo(wrap(Utf8(Cow::from("some/package/Class"))))),
+                wrap(NameAndType(
+                    wrap(Utf8(Cow::from("someMethod"))),
+                    wrap(Utf8(Cow::from("()V"))),
+                )),
+            ))
+        ));
+
+        assert_validate_fails!(
+            MethodHandle(kind, wrap(Zero)),
+            "Unexpected constant pool reference type"
+        );
+    }
+
+    for kind in [InvokeStatic, InvokeSpecial] {
+        assert_validate_passes!(MethodHandle(
+            kind,
+            wrap(MethodRef(
+                wrap(ClassInfo(wrap(Utf8(Cow::from("some/package/Class"))))),
+                wrap(NameAndType(
+                    wrap(Utf8(Cow::from("someMethod"))),
+                    wrap(Utf8(Cow::from("()V"))),
+                )),
+            ))
+        ));
+        assert_validate_passes!(
+            52, // Major version
+            MethodHandle(
+                kind,
+                wrap(InterfaceMethodRef(
+                    wrap(ClassInfo(wrap(Utf8(Cow::from("some/package/Class"))))),
+                    wrap(NameAndType(
+                        wrap(Utf8(Cow::from("someMethod"))),
+                        wrap(Utf8(Cow::from("()V"))),
+                    )),
+                ))
+            )
+        );
+
+        assert_validate_fails!(
+            51, // Major version
+            MethodHandle(
+                kind,
+                wrap(InterfaceMethodRef(
+                    wrap(ClassInfo(wrap(Utf8(Cow::from("some/package/Class"))))),
+                    wrap(NameAndType(
+                        wrap(Utf8(Cow::from("someMethod"))),
+                        wrap(Utf8(Cow::from("()V"))),
+                    )),
+                ))
+            ),
+            "Unexpected constant pool reference type"
+        );
+        assert_validate_fails!(
+            MethodHandle(kind, wrap(Zero)),
+            "Unexpected constant pool reference type"
+        );
+    }
+
+    for kind in [InvokeInterface] {
+        assert_validate_passes!(MethodHandle(
+            kind,
+            wrap(InterfaceMethodRef(
+                wrap(ClassInfo(wrap(Utf8(Cow::from("some/package/Class"))))),
+                wrap(NameAndType(
+                    wrap(Utf8(Cow::from("someMethod"))),
+                    wrap(Utf8(Cow::from("()V"))),
+                )),
+            ))
+        ));
+
+        assert_validate_fails!(
+            MethodHandle(kind, wrap(Zero)),
+            "Unexpected constant pool reference type"
+        );
+    }
+}
+
+#[test]
+fn test_validate_method_type() {
+    assert_validate_passes!(MethodType(wrap(Utf8(Cow::from("()V")))));
+
+    assert_validate_fails!(
+        MethodType(wrap(Utf8(Cow::from("")))),
+        "Invalid method descriptor"
+    );
+    assert_validate_panics!(MethodType(wrap(Utf8Bytes(&[]))));
+    assert_validate_fails!(
+        MethodType(wrap(Zero)),
+        "Unexpected constant pool reference type"
+    );
+}
+
+#[test]
+fn test_validate_dynamic() {
+    assert_validate_passes!(Dynamic(
+        0,
+        wrap(NameAndType(
+            wrap(Utf8(Cow::from("someField"))),
+            wrap(Utf8(Cow::from("I"))),
+        )),
+    ));
+    assert_validate_passes!(Dynamic(
+        0,
+        wrap(NameAndType(
+            wrap(Utf8(Cow::from(""))),
+            wrap(Utf8(Cow::from("I"))),
+        )),
+    ));
+    assert_validate_passes!(Dynamic(
+        0,
+        wrap(NameAndType(
+            wrap(Utf8Bytes(&[])),
+            wrap(Utf8(Cow::from("I"))),
+        )),
+    ));
+
+    assert_validate_fails!(
+        Dynamic(0, wrap(Zero)),
+        "Unexpected constant pool reference type"
+    );
+    assert_validate_fails!(
+        Dynamic(
+            0,
+            wrap(NameAndType(
+                wrap(Utf8(Cow::from("someField"))),
+                wrap(Utf8(Cow::from(""))),
+            )),
+        ),
+        "Invalid field descriptor"
+    );
+    assert_validate_panics!(Dynamic(
+        0,
+        wrap(NameAndType(
+            wrap(Utf8(Cow::from("someField"))),
+            wrap(Utf8Bytes(&[]))
+        )),
+    ));
+}
+
+#[test]
+fn test_validate_invoke_dynamic() {
+    assert_validate_passes!(InvokeDynamic(
+        0,
+        wrap(NameAndType(
+            wrap(Utf8(Cow::from("someMethod"))),
+            wrap(Utf8(Cow::from("()V"))),
+        )),
+    ));
+    assert_validate_passes!(InvokeDynamic(
+        0,
+        wrap(NameAndType(
+            wrap(Utf8(Cow::from(""))),
+            wrap(Utf8(Cow::from("()V"))),
+        )),
+    ));
+    assert_validate_passes!(InvokeDynamic(
+        0,
+        wrap(NameAndType(
+            wrap(Utf8Bytes(&[])),
+            wrap(Utf8(Cow::from("()V"))),
+        )),
+    ));
+
+    assert_validate_fails!(
+        InvokeDynamic(0, wrap(Zero)),
+        "Unexpected constant pool reference type"
+    );
+    assert_validate_fails!(
+        InvokeDynamic(
+            0,
+            wrap(NameAndType(
+                wrap(Utf8(Cow::from("someMethod"))),
+                wrap(Utf8(Cow::from(""))),
+            )),
+        ),
+        "Invalid method descriptor"
+    );
+    assert_validate_panics!(InvokeDynamic(
+        0,
+        wrap(NameAndType(
+            wrap(Utf8(Cow::from("someMethod"))),
+            wrap(Utf8Bytes(&[]))
+        )),
+    ));
+}
+
+#[test]
+fn test_validate_module_info() {
+    assert_validate_passes!(ModuleInfo(wrap(Utf8(Cow::from("some.module")))));
+
+    assert_validate_fails!(
+        ModuleInfo(wrap(Utf8(Cow::from("@")))),
+        "Invalid module name"
+    );
+    assert_validate_panics!(ModuleInfo(wrap(Utf8Bytes(&[]))));
+    assert_validate_fails!(
+        ModuleInfo(wrap(Zero)),
+        "Unexpected constant pool reference type"
+    );
+}
+
+#[test]
+fn test_validate_invoke_package_info() {
+    assert_validate_passes!(PackageInfo(wrap(Utf8(Cow::from("some/package")))));
+
+    assert_validate_fails!(
+        PackageInfo(wrap(Utf8(Cow::from("")))),
+        "Invalid binary name"
+    );
+    assert_validate_panics!(PackageInfo(wrap(Utf8Bytes(&[]))));
+    assert_validate_fails!(
+        PackageInfo(wrap(Zero)),
+        "Unexpected constant pool reference type"
+    );
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -39,7 +39,7 @@ macro_rules! fail {
     };
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct ParseError {
     msg: String,
     contexts: Vec<String>,


### PR DESCRIPTION
Fixes #7 .

Additional simplifications are possible after this: Many calls to `ensure_type` are no longer required. But I decided to keep this pull request focused on the bug fix.

* First commits add unit tests
* Next commits factor out a new helper `str` to be used where proper UTF-8 is required.
* Last commit turns the panic into a failure in `str`.