### PR TITLE
Change validation methods from Result<bool> to Result<()>

### DIFF
--- a/src/constant_pool/tests.rs
+++ b/src/constant_pool/tests.rs
@@ -3,10 +3,10 @@ use ConstantPoolEntry::*;
 
 macro_rules! assert_validate_passes {
     ($entry:expr) => {
-        assert_eq!($entry.validate(0), Ok(true));
+        assert_eq!($entry.validate(0), Ok(()));
     };
     ($version:literal, $entry:expr) => {
-        assert_eq!($entry.validate($version), Ok(true));
+        assert_eq!($entry.validate($version), Ok(()));
     };
 }
 


### PR DESCRIPTION
It seems cleaner that way: When a method returns `Result<bool>`, I wonder what the meaning of the Boolean is. If it returns `Result<()>`, it's obvious that there is no meaningful return value (beyond `Ok` or `Err`).

Also cleaned up some unnecessary assertions.