### PR TITLE
Descriptor parser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /target
 Cargo.lock
+
+tests/parse/tgz/openjdk16.0.1-modules

--- a/src/constant_pool.rs
+++ b/src/constant_pool.rs
@@ -902,7 +902,6 @@ pub(crate) fn read_cp_invokedynamic<'a>(
     }
 }
 
-#[allow(dead_code)]
 #[derive(Debug)]
 pub struct Dynamic<'a> {
     attr_index: u16,

--- a/src/constant_pool.rs
+++ b/src/constant_pool.rs
@@ -902,6 +902,7 @@ pub(crate) fn read_cp_invokedynamic<'a>(
     }
 }
 
+#[allow(dead_code)]
 #[derive(Debug)]
 pub struct Dynamic<'a> {
     attr_index: u16,

--- a/src/descriptor.rs
+++ b/src/descriptor.rs
@@ -8,7 +8,7 @@ use std::{
 
 use crate::ParseError;
 
-/// MethodDescriptor as described in section 4.3.3 of the [JVM 18 specification](https://docs.oracle.com/javase/specs/jvms/se18/jvms18.pdf)
+/// MethodDescriptor as described in section 4.3.3 of the [JVM 18 specification](https://docs.oracle.com/javase/specs/jvms/se18/html/jvms-4.html#jvms-4.3.3)
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct MethodDescriptor<'a> {
     pub parameters: Vec<FieldType<'a>>,
@@ -58,7 +58,7 @@ impl<'a> fmt::Display for MethodDescriptor<'a> {
     }
 }
 
-/// FieldType as described in section 4.3.2 of the [JVM 18 specification](https://docs.oracle.com/javase/specs/jvms/se18/jvms18.pdf)
+/// FieldType as described in section 4.3.2 of the [JVM 18 specification](https://docs.oracle.com/javase/specs/jvms/se18/html/jvms-4.html#jvms-4.3.2)
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub enum FieldType<'a> {
     Base(BaseType),
@@ -97,38 +97,38 @@ impl<'a> fmt::Display for FieldType<'a> {
     }
 }
 
-/// BaseType as described in Table 4.3-A. of the [JVM 18 specification](https://docs.oracle.com/javase/specs/jvms/se18/jvms18.pdf)
+/// BaseType as described in Table 4.3-A. of the [JVM 18 specification](https://docs.oracle.com/javase/specs/jvms/se18/html/jvms-4.html#jvms-4.3.2-200)
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub enum BaseType {
     /// B, byte, signed byte
-    BYTE,
+    Byte,
     /// C, char, Unicode character code point in the Basic Multilingual Plane, encoded with UTF-16
-    CHAR,
+    Char,
     /// D, double, double-precision floating-point value
-    DOUBLE,
+    Double,
     /// F, float, single-precision floating-point value
-    FLOAT,
+    Float,
     /// I, int, integer
-    INT,
+    Int,
     /// J, long, long integer
-    LONG,
+    Long,
     /// S, short, signed short
-    SHORT,
+    Short,
     /// Z, boolean, true or false
-    BOOLEAN,
+    Boolean,
 }
 
 impl BaseType {
     fn parse(ch: char) -> Result<Self, ParseError> {
         let this = match ch {
-            'B' => Self::BYTE,
-            'C' => Self::CHAR,
-            'D' => Self::DOUBLE,
-            'F' => Self::FLOAT,
-            'I' => Self::INT,
-            'J' => Self::LONG,
-            'S' => Self::SHORT,
-            'Z' => Self::BOOLEAN,
+            'B' => Self::Byte,
+            'C' => Self::Char,
+            'D' => Self::Double,
+            'F' => Self::Float,
+            'I' => Self::Int,
+            'J' => Self::Long,
+            'S' => Self::Short,
+            'Z' => Self::Boolean,
             _ => fail!("Invalid base type {}", ch),
         };
 
@@ -139,14 +139,14 @@ impl BaseType {
 impl fmt::Display for BaseType {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         let c = match self {
-            Self::BYTE => 'B',
-            Self::CHAR => 'C',
-            Self::DOUBLE => 'D',
-            Self::FLOAT => 'F',
-            Self::INT => 'I',
-            Self::LONG => 'J',
-            Self::SHORT => 'S',
-            Self::BOOLEAN => 'Z',
+            Self::Byte => 'B',
+            Self::Char => 'C',
+            Self::Double => 'D',
+            Self::Float => 'F',
+            Self::Int => 'I',
+            Self::Long => 'J',
+            Self::Short => 'S',
+            Self::Boolean => 'Z',
         };
 
         f.write_char(c)
@@ -243,7 +243,7 @@ mod tests {
         let mut parameters = descriptor.parameters.into_iter();
         let result = descriptor.result;
 
-        assert_eq!(parameters.next().unwrap(), FieldType::Base(BaseType::LONG));
+        assert_eq!(parameters.next().unwrap(), FieldType::Base(BaseType::Long));
         assert!(parameters.next().is_none());
         assert_eq!(result, ReturnDescriptor::Void);
     }
@@ -259,7 +259,7 @@ mod tests {
         assert!(parameters.next().is_none());
         assert_eq!(
             result,
-            ReturnDescriptor::Return(FieldType::Base(BaseType::LONG))
+            ReturnDescriptor::Return(FieldType::Base(BaseType::Long))
         );
     }
 
@@ -271,19 +271,19 @@ mod tests {
         let mut parameters = descriptor.parameters.into_iter();
         let result = descriptor.result;
 
-        assert_eq!(parameters.next().unwrap(), FieldType::Base(BaseType::BYTE));
-        assert_eq!(parameters.next().unwrap(), FieldType::Base(BaseType::CHAR));
+        assert_eq!(parameters.next().unwrap(), FieldType::Base(BaseType::Byte));
+        assert_eq!(parameters.next().unwrap(), FieldType::Base(BaseType::Char));
         assert_eq!(
             parameters.next().unwrap(),
-            FieldType::Base(BaseType::DOUBLE)
+            FieldType::Base(BaseType::Double)
         );
-        assert_eq!(parameters.next().unwrap(), FieldType::Base(BaseType::FLOAT));
-        assert_eq!(parameters.next().unwrap(), FieldType::Base(BaseType::INT));
-        assert_eq!(parameters.next().unwrap(), FieldType::Base(BaseType::LONG));
-        assert_eq!(parameters.next().unwrap(), FieldType::Base(BaseType::SHORT));
+        assert_eq!(parameters.next().unwrap(), FieldType::Base(BaseType::Float));
+        assert_eq!(parameters.next().unwrap(), FieldType::Base(BaseType::Int));
+        assert_eq!(parameters.next().unwrap(), FieldType::Base(BaseType::Long));
+        assert_eq!(parameters.next().unwrap(), FieldType::Base(BaseType::Short));
         assert_eq!(
             parameters.next().unwrap(),
-            FieldType::Base(BaseType::BOOLEAN)
+            FieldType::Base(BaseType::Boolean)
         );
         assert!(parameters.next().is_none());
         assert_eq!(result, ReturnDescriptor::Void);
@@ -366,7 +366,7 @@ mod tests {
 
         assert_eq!(
             parameters.next().unwrap(),
-            FieldType::Array(Box::new(FieldType::Base(BaseType::LONG)))
+            FieldType::Array(Box::new(FieldType::Base(BaseType::Long)))
         );
         assert!(parameters.next().is_none());
         assert_eq!(result, ReturnDescriptor::Void);
@@ -383,7 +383,7 @@ mod tests {
         assert_eq!(
             parameters.next().unwrap(),
             FieldType::Array(Box::new(FieldType::Array(Box::new(FieldType::Base(
-                BaseType::LONG
+                BaseType::Long
             )))))
         );
         assert!(parameters.next().is_none());
@@ -401,7 +401,7 @@ mod tests {
         assert!(parameters.next().is_none());
         assert_eq!(
             result,
-            ReturnDescriptor::Return(FieldType::Array(Box::new(FieldType::Base(BaseType::LONG))))
+            ReturnDescriptor::Return(FieldType::Array(Box::new(FieldType::Base(BaseType::Long))))
         );
     }
 
@@ -409,9 +409,9 @@ mod tests {
     fn test_display() {
         let descriptor = MethodDescriptor {
             parameters: vec![
-                FieldType::Base(BaseType::LONG),
+                FieldType::Base(BaseType::Long),
                 FieldType::Object(Cow::Borrowed("java/lang/Object")),
-                FieldType::Array(Box::new(FieldType::Base(BaseType::BYTE))),
+                FieldType::Array(Box::new(FieldType::Base(BaseType::Byte))),
             ],
             result: ReturnDescriptor::Void,
         };

--- a/src/descriptor.rs
+++ b/src/descriptor.rs
@@ -1,0 +1,314 @@
+use std::{borrow::Cow, str::Chars};
+
+use crate::ParseError;
+
+/// MethodDescriptor as described in section 4.3.3 of the [JVM 18 specification](https://docs.oracle.com/javase/specs/jvms/se18/jvms18.pdf)
+#[derive(Debug, PartialEq, Eq)]
+pub struct MethodDescriptor<'a> {
+    pub parameters: Vec<FieldType<'a>>,
+    pub result: ReturnDescriptor<'a>,
+}
+
+impl<'a> MethodDescriptor<'a> {
+    fn parse(chars: &mut Chars<'a>) -> Result<Self, ParseError> {
+        match chars.next() {
+            Some('(') => (),
+            Some(c) => fail!("Invalid start of method descriptor {}", c),
+            None => fail!("Invalid start of method descriptor, missing ("),
+        };
+
+        let mut parameters: Vec<FieldType> = Vec::new();
+
+        'done: loop {
+            let field = match chars.as_str().chars().next() {
+                Some(')') => break 'done,
+                Some(_) => FieldType::parse(chars)?,
+                None => fail!("Invalid method descriptor, missing end )"),
+            };
+
+            parameters.push(field);
+        }
+
+        // consume the final ')'
+        chars.next();
+        let result = ReturnDescriptor::parse(chars)?;
+
+        Ok(MethodDescriptor { parameters, result })
+    }
+}
+
+/// FieldType as described in section 4.3.2 of the [JVM 18 specification](https://docs.oracle.com/javase/specs/jvms/se18/jvms18.pdf)
+#[derive(Debug, PartialEq, Eq)]
+pub enum FieldType<'a> {
+    Base(BaseType),
+    Object(Cow<'a, str>),
+    Array(Box<FieldType<'a>>),
+}
+
+impl<'a> FieldType<'a> {
+    fn parse(chars: &mut Chars<'a>) -> Result<Self, ParseError> {
+        let field = match chars.next() {
+            Some('L') => Self::Object(parse_object(chars)?),
+            Some('[') => Self::Array(Box::new(FieldType::parse(chars)?)),
+            Some(ch) => Self::Base(BaseType::parse(ch)?),
+            None => fail!("Invalid FieldType"),
+        };
+
+        Ok(field)
+    }
+}
+
+/// BaseType as described in Table 4.3-A. of the [JVM 18 specification](https://docs.oracle.com/javase/specs/jvms/se18/jvms18.pdf)
+#[derive(Debug, PartialEq, Eq)]
+pub enum BaseType {
+    /// B, byte, signed byte
+    BYTE,
+    /// C, char, Unicode character code point in the Basic Multilingual Plane, encoded with UTF-16
+    CHAR,
+    /// D, double, double-precision floating-point value
+    DOUBLE,
+    /// F, float, single-precision floating-point value
+    FLOAT,
+    /// I, int, integer
+    INT,
+    /// J, long, long integer
+    LONG,
+    /// S, short, signed short
+    SHORT,
+    /// Z, boolean, true or false
+    BOOLEAN,
+}
+
+impl BaseType {
+    fn parse(ch: char) -> Result<Self, ParseError> {
+        let this = match ch {
+            'B' => Self::BYTE,
+            'C' => Self::CHAR,
+            'D' => Self::DOUBLE,
+            'F' => Self::FLOAT,
+            'I' => Self::INT,
+            'J' => Self::LONG,
+            'S' => Self::SHORT,
+            'Z' => Self::BOOLEAN,
+            _ => fail!("Invalid base type {}", ch),
+        };
+
+        Ok(this)
+    }
+}
+
+/// ReturnDescriptor
+#[derive(Debug, PartialEq, Eq)]
+pub enum ReturnDescriptor<'a> {
+    Return(FieldType<'a>),
+    Void,
+}
+
+impl<'a> ReturnDescriptor<'a> {
+    fn parse(chars: &mut Chars<'a>) -> Result<Self, ParseError> {
+        let result = match chars.as_str().chars().next() {
+            Some('V') => Self::Void,
+            Some(_) => Self::Return(FieldType::parse(chars)?),
+            None => fail!("Invalid return descriptor, missing value"),
+        };
+
+        Ok(result)
+    }
+}
+
+/// Parses the object less the beginning L, e.g. this expects `java/lang/Object;`
+fn parse_object<'a>(chars: &mut Chars<'a>) -> Result<Cow<'a, str>, ParseError> {
+    // match chars.next() {
+    //     Some('L') => (),
+    //     Some(ch) => fail!("Invalid object descriptor, expected L {}", ch),
+    //     None => fail!("Invalid object descriptor, expected L"),
+    // };
+
+    if !chars.clone().any(|ch| ch == ';') {
+        fail!("Invalid object descriptor, expected ;");
+    }
+
+    let object: String = chars.by_ref().take_while(|ch| *ch != ';').collect();
+    Ok(Cow::Owned(object))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_void_void() {
+        let string = "()V";
+        let mut chars = string.chars();
+
+        let descriptor = MethodDescriptor::parse(&mut chars).unwrap();
+        let mut parameters = descriptor.parameters.into_iter();
+        let result = descriptor.result;
+
+        assert!(parameters.next().is_none());
+        assert_eq!(result, ReturnDescriptor::Void);
+    }
+
+    #[test]
+    fn test_single_param() {
+        let string = "(J)V";
+        let mut chars = string.chars();
+
+        let descriptor = MethodDescriptor::parse(&mut chars).unwrap();
+        let mut parameters = descriptor.parameters.into_iter();
+        let result = descriptor.result;
+
+        assert_eq!(parameters.next().unwrap(), FieldType::Base(BaseType::LONG));
+        assert!(parameters.next().is_none());
+        assert_eq!(result, ReturnDescriptor::Void);
+    }
+
+    #[test]
+    fn test_basetype_return() {
+        let string = "()J";
+        let mut chars = string.chars();
+
+        let descriptor = MethodDescriptor::parse(&mut chars).unwrap();
+        let mut parameters = descriptor.parameters.into_iter();
+        let result = descriptor.result;
+
+        assert!(parameters.next().is_none());
+        assert_eq!(
+            result,
+            ReturnDescriptor::Return(FieldType::Base(BaseType::LONG))
+        );
+    }
+
+    #[test]
+    fn test_all_basetype_params() {
+        let string = "(BCDFIJSZ)V";
+        let mut chars = string.chars();
+
+        let descriptor = MethodDescriptor::parse(&mut chars).unwrap();
+        let mut parameters = descriptor.parameters.into_iter();
+        let result = descriptor.result;
+
+        assert_eq!(parameters.next().unwrap(), FieldType::Base(BaseType::BYTE));
+        assert_eq!(parameters.next().unwrap(), FieldType::Base(BaseType::CHAR));
+        assert_eq!(
+            parameters.next().unwrap(),
+            FieldType::Base(BaseType::DOUBLE)
+        );
+        assert_eq!(parameters.next().unwrap(), FieldType::Base(BaseType::FLOAT));
+        assert_eq!(parameters.next().unwrap(), FieldType::Base(BaseType::INT));
+        assert_eq!(parameters.next().unwrap(), FieldType::Base(BaseType::LONG));
+        assert_eq!(parameters.next().unwrap(), FieldType::Base(BaseType::SHORT));
+        assert_eq!(
+            parameters.next().unwrap(),
+            FieldType::Base(BaseType::BOOLEAN)
+        );
+        assert!(parameters.next().is_none());
+        assert_eq!(result, ReturnDescriptor::Void);
+    }
+
+    #[test]
+    fn test_object_param() {
+        let string = "(Ljava/lang/Object;)V";
+        let mut chars = string.chars();
+
+        let descriptor = MethodDescriptor::parse(&mut chars).unwrap();
+        let mut parameters = descriptor.parameters.into_iter();
+        let result = descriptor.result;
+
+        assert_eq!(
+            parameters.next().unwrap(),
+            FieldType::Object(Cow::Borrowed("java/lang/Object"))
+        );
+        assert!(parameters.next().is_none());
+        assert_eq!(result, ReturnDescriptor::Void);
+    }
+
+    #[test]
+    fn test_multi_object_param() {
+        let string = "(Ljava/lang/Object;Ljava/lang/String;)V";
+        let mut chars = string.chars();
+
+        let descriptor = MethodDescriptor::parse(&mut chars).unwrap();
+        let mut parameters = descriptor.parameters.into_iter();
+        let result = descriptor.result;
+
+        assert_eq!(
+            parameters.next().unwrap(),
+            FieldType::Object(Cow::Borrowed("java/lang/Object"))
+        );
+        assert_eq!(
+            parameters.next().unwrap(),
+            FieldType::Object(Cow::Borrowed("java/lang/String"))
+        );
+        assert!(parameters.next().is_none());
+        assert_eq!(result, ReturnDescriptor::Void);
+    }
+
+    #[test]
+    fn test_object_return() {
+        let string = "()Ljava/lang/Object;";
+        let mut chars = string.chars();
+
+        let descriptor = MethodDescriptor::parse(&mut chars).unwrap();
+        let mut parameters = descriptor.parameters.into_iter();
+        let result = descriptor.result;
+
+        assert!(parameters.next().is_none());
+        assert_eq!(
+            result,
+            ReturnDescriptor::Return(FieldType::Object(Cow::Borrowed("java/lang/Object")))
+        );
+    }
+
+    #[test]
+    fn test_array_basetype_param() {
+        let string = "([J)V";
+        let mut chars = string.chars();
+
+        let descriptor = MethodDescriptor::parse(&mut chars).unwrap();
+        let mut parameters = descriptor.parameters.into_iter();
+        let result = descriptor.result;
+
+        assert_eq!(
+            parameters.next().unwrap(),
+            FieldType::Array(Box::new(FieldType::Base(BaseType::LONG)))
+        );
+        assert!(parameters.next().is_none());
+        assert_eq!(result, ReturnDescriptor::Void);
+    }
+
+    #[test]
+    fn test_multi_array_param() {
+        let string = "([[J)V";
+        let mut chars = string.chars();
+
+        let descriptor = MethodDescriptor::parse(&mut chars).unwrap();
+        let mut parameters = descriptor.parameters.into_iter();
+        let result = descriptor.result;
+
+        assert_eq!(
+            parameters.next().unwrap(),
+            FieldType::Array(Box::new(FieldType::Array(Box::new(FieldType::Base(
+                BaseType::LONG
+            )))))
+        );
+        assert!(parameters.next().is_none());
+        assert_eq!(result, ReturnDescriptor::Void);
+    }
+
+    #[test]
+    fn test_array_return() {
+        let string = "()[J";
+        let mut chars = string.chars();
+
+        let descriptor = MethodDescriptor::parse(&mut chars).unwrap();
+        let mut parameters = descriptor.parameters.into_iter();
+        let result = descriptor.result;
+
+        assert!(parameters.next().is_none());
+        assert_eq!(
+            result,
+            ReturnDescriptor::Return(FieldType::Array(Box::new(FieldType::Base(BaseType::LONG))))
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,7 +137,7 @@ bitflags! {
 pub struct FieldInfo<'a> {
     pub access_flags: FieldAccessFlags,
     pub name: Cow<'a, str>,
-    pub descriptor: FieldType,
+    pub descriptor: FieldType<'a>,
     pub attributes: Vec<AttributeInfo<'a>>,
 }
 
@@ -149,7 +149,7 @@ fn read_fields<'a>(
 ) -> Result<Vec<FieldInfo<'a>>, ParseError> {
     let count = read_u2(bytes, ix)?;
     let mut fields = Vec::with_capacity(count.into());
-    let mut unique_ids: HashSet<(Cow<'a, str>, FieldType)> = HashSet::new();
+    let mut unique_ids: HashSet<(Cow<'a, str>, FieldType<'a>)> = HashSet::new();
     for i in 0..count {
         let access_flags = FieldAccessFlags::from_bits_truncate(read_u2(bytes, ix)?);
         let name =
@@ -163,8 +163,7 @@ fn read_fields<'a>(
             fail!("Invalid descriptor for class field {}", i);
         }
 
-        let mut descriptor = descriptor.chars();
-        let descriptor = FieldType::parse(&mut descriptor)?;
+        let descriptor = FieldType::parse(&descriptor)?;
 
         let unique_id = (name.clone(), descriptor.clone());
         if !unique_ids.insert(unique_id) {
@@ -206,7 +205,7 @@ bitflags! {
 pub struct MethodInfo<'a> {
     pub access_flags: MethodAccessFlags,
     pub name: Cow<'a, str>,
-    pub descriptor: MethodDescriptor,
+    pub descriptor: MethodDescriptor<'a>,
     pub attributes: Vec<AttributeInfo<'a>>,
 }
 
@@ -220,7 +219,7 @@ fn read_methods<'a>(
 ) -> Result<Vec<MethodInfo<'a>>, ParseError> {
     let count = read_u2(bytes, ix)?;
     let mut methods = Vec::with_capacity(count.into());
-    let mut unique_ids: HashSet<(Cow<'a, str>, MethodDescriptor)> = HashSet::new();
+    let mut unique_ids: HashSet<(Cow<'a, str>, MethodDescriptor<'a>)> = HashSet::new();
     for i in 0..count {
         let access_flags = MethodAccessFlags::from_bits_truncate(read_u2(bytes, ix)?);
         let name =
@@ -234,8 +233,7 @@ fn read_methods<'a>(
         if !is_method_descriptor(&descriptor) {
             fail!("Invalid descriptor for class method {}", i);
         }
-        let mut descriptor = descriptor.chars();
-        let descriptor = MethodDescriptor::parse(&mut descriptor)?;
+        let descriptor = MethodDescriptor::parse(&descriptor)?;
 
         if allow_init && name == "<init>" && descriptor.result != ReturnDescriptor::Void {
             fail!("Non-void method descriptor for init method {}", i);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@ use crate::constant_pool::{
 };
 use crate::descriptor::{FieldType, MethodDescriptor, ReturnDescriptor};
 pub use crate::error::ParseError;
-use crate::names::{is_field_descriptor, is_method_descriptor, is_unqualified_name};
+use crate::names::is_unqualified_name;
 
 pub(crate) fn read_u1(bytes: &[u8], ix: &mut usize) -> Result<u8, ParseError> {
     if bytes.len() < *ix + 1 {
@@ -159,10 +159,6 @@ fn read_fields<'a>(
         }
         let descriptor = read_cp_utf8(bytes, ix, pool)
             .map_err(|e| err!(e, "descriptor of class field {}", i))?;
-        if !is_field_descriptor(&descriptor) {
-            fail!("Invalid descriptor for class field {}", i);
-        }
-
         let descriptor = FieldType::parse(&descriptor)?;
 
         let unique_id = (name.clone(), descriptor.clone());
@@ -230,9 +226,6 @@ fn read_methods<'a>(
         }
         let descriptor = read_cp_utf8(bytes, ix, pool)
             .map_err(|e| err!(e, "descriptor of class method {}", i))?;
-        if !is_method_descriptor(&descriptor) {
-            fail!("Invalid descriptor for class method {}", i);
-        }
         let descriptor = MethodDescriptor::parse(&descriptor)?;
 
         if allow_init && name == "<init>" && descriptor.result != ReturnDescriptor::Void {


### PR DESCRIPTION
This adds descriptor parsing for both method_info (`MethodDescriptor`) as well as field_info (`FieldType`).

Fixes: #18