### PR TITLE
Implement std::error::Error for ParseError

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -74,3 +74,5 @@ impl fmt::Display for ParseError {
         Ok(())
     }
 }
+
+impl std::error::Error for ParseError {}


### PR DESCRIPTION
This will allow the ParseError to play nicely with other error systems, like `thiserror`.