### PR TITLE
Fix: Prevent out of range reads in ConstantPoolIter

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -39,7 +39,7 @@ macro_rules! fail {
     };
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct ParseError {
     msg: String,
     contexts: Vec<String>,


### PR DESCRIPTION
Hi,

It is currently possible (and it fact, it has happened to me on a few occasions) that the ConstantPoolIter panicks with an out-of-range read.

This PR fixes it.
