### PR TITLE
Type-safe descriptors in AttributeData

### DIFF
--- a/src/attributes.rs
+++ b/src/attributes.rs
@@ -774,7 +774,7 @@ fn read_type_annotation_data<'a>(
                 type_parameter_index: read_u1(bytes, ix)?,
                 bound_index: read_u1(bytes, ix)?,
             },
-            0x13 | 0x14 | 0x15 => TypeAnnotationTarget::Empty,
+            0x13..=0x15 => TypeAnnotationTarget::Empty,
             0x16 => TypeAnnotationTarget::FormalParameter {
                 index: read_u1(bytes, ix)?,
             },
@@ -799,10 +799,10 @@ fn read_type_annotation_data<'a>(
             0x42 => TypeAnnotationTarget::Catch {
                 exception_table_index: read_u2(bytes, ix)?,
             },
-            0x43 | 0x44 | 0x45 | 0x46 => TypeAnnotationTarget::Offset {
+            0x43..=0x46 => TypeAnnotationTarget::Offset {
                 offset: read_u2(bytes, ix)?,
             },
-            0x47 | 0x48 | 0x49 | 0x4A | 0x4B => TypeAnnotationTarget::TypeArgument {
+            0x47..=0x4B => TypeAnnotationTarget::TypeArgument {
                 offset: read_u2(bytes, ix)?,
                 type_argument_index: read_u1(bytes, ix)?,
             },

--- a/src/attributes.rs
+++ b/src/attributes.rs
@@ -148,7 +148,7 @@ pub struct AnnotationElement<'a> {
 
 #[derive(Debug)]
 pub struct Annotation<'a> {
-    pub type_descriptor: Cow<'a, str>,
+    pub type_descriptor: FieldType<'a>,
     pub elements: Vec<AnnotationElement<'a>>,
 }
 
@@ -702,11 +702,9 @@ fn read_annotation<'a>(
     ix: &mut usize,
     pool: &[Rc<ConstantPoolEntry<'a>>],
 ) -> Result<Annotation<'a>, ParseError> {
-    let type_descriptor =
-        read_cp_utf8(bytes, ix, pool).map_err(|e| err!(e, "type descriptor field"))?;
-    if !is_field_descriptor(&type_descriptor) {
-        fail!("Invalid descriptor");
-    }
+    let type_descriptor = read_cp_utf8(bytes, ix, pool)
+        .and_then(|descriptor| FieldType::parse(&descriptor))
+        .map_err(|e| err!(e, "type descriptor field"))?;
     let element_count = read_u2(bytes, ix)?;
     let mut elements = Vec::with_capacity(element_count.into());
     for i in 0..element_count {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -328,13 +328,15 @@ pub struct ParseOptions {
     parse_bytecode: bool,
 }
 
-impl ParseOptions {
-    pub fn default() -> Self {
+impl Default for ParseOptions {
+    fn default() -> Self {
         Self {
             parse_bytecode: true,
         }
     }
+}
 
+impl ParseOptions {
     /// Turns on or off parsing of bytecode from the Code attributes of methods. If parsing
     /// is enabled, the CodeData structure's optional bytecode field will be populated
     /// (or parsing will fail entirely if bytecode parsing failed). If parsing is disabled,


### PR DESCRIPTION
Exposes descriptors in `AttributeData` in a type safe way through `FieldType`.