### PR TITLE
Re-add Display trait on descriptors

### DIFF
--- a/src/descriptors.rs
+++ b/src/descriptors.rs
@@ -3,7 +3,6 @@ use std::{
     fmt::{self, Write},
 };
 
-
 use crate::ParseError;
 
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
@@ -55,7 +54,7 @@ impl<'a> ClassName<'a> {
 }
 impl<'a> fmt::Display for ClassName<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        let segments : Vec<Cow<'a, str>> = self.segments.iter().map(|s| s.name.clone()).collect();
+        let segments: Vec<Cow<'a, str>> = self.segments.iter().map(|s| s.name.clone()).collect();
         write!(f, "{}", segments.join("/"))
     }
 }
@@ -106,17 +105,17 @@ impl<'a> FieldType<'a> {
     }
 }
 
-impl<'a> fmt::Display for FieldType<'a> {
+impl fmt::Display for FieldType<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         match self {
-            Self::Byte     => write!(f, "B"),
-            Self::Char     => write!(f, "C"),
-            Self::Double   => write!(f, "D"),
-            Self::Float    => write!(f, "F"),
-            Self::Integer  => write!(f, "I"),
-            Self::Long     => write!(f, "J"),
-            Self::Short    => write!(f, "S"),
-            Self::Boolean  => write!(f, "Z"),
+            Self::Byte => write!(f, "B"),
+            Self::Char => write!(f, "C"),
+            Self::Double => write!(f, "D"),
+            Self::Float => write!(f, "F"),
+            Self::Integer => write!(f, "I"),
+            Self::Long => write!(f, "J"),
+            Self::Short => write!(f, "S"),
+            Self::Boolean => write!(f, "Z"),
             Self::Object(obj) => write!(f, "L{};", obj),
         }
     }
@@ -134,10 +133,15 @@ impl<'a> FieldDescriptor<'a> {
     }
 }
 
-impl<'a> fmt::Display for FieldDescriptor<'a> {
+impl fmt::Display for FieldDescriptor<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         if self.dimensions > 0 {
-            write!(f, "{}{}", "[".repeat(self.dimensions as usize), self.field_type)
+            write!(
+                f,
+                "{}{}",
+                "[".repeat(self.dimensions as usize),
+                self.field_type
+            )
         } else {
             write!(f, "{}", self.field_type)
         }
@@ -184,7 +188,7 @@ pub enum ReturnDescriptor<'a> {
     Return(FieldDescriptor<'a>),
     Void,
 }
-impl<'a> fmt::Display for ReturnDescriptor<'a> {
+impl fmt::Display for ReturnDescriptor<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         match self {
             Self::Void => f.write_char('V'),
@@ -221,7 +225,7 @@ pub struct MethodDescriptor<'a> {
     pub return_type: ReturnDescriptor<'a>,
 }
 
-impl<'a> fmt::Display for MethodDescriptor<'a> {
+impl fmt::Display for MethodDescriptor<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         f.write_char('(')?;
 

--- a/src/descriptors.rs
+++ b/src/descriptors.rs
@@ -55,7 +55,7 @@ impl<'a> ClassName<'a> {
 impl<'a> fmt::Display for ClassName<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         let segments: Vec<Cow<'a, str>> = self.segments.iter().map(|s| s.name.clone()).collect();
-        write!(f, "{}", segments.join("/"))
+        write!(f, "{};", segments.join("/"))
     }
 }
 
@@ -135,16 +135,12 @@ impl<'a> FieldDescriptor<'a> {
 
 impl fmt::Display for FieldDescriptor<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        if self.dimensions > 0 {
-            write!(
-                f,
-                "{}{}",
-                "[".repeat(self.dimensions as usize),
-                self.field_type
-            )
-        } else {
-            write!(f, "{}", self.field_type)
-        }
+        write!(
+            f,
+            "{}{}",
+            "[".repeat(self.dimensions as usize),
+            self.field_type
+        )
     }
 }
 


### PR DESCRIPTION
Hey hey,

I appreciate this crate and the work you do!

I was going about upgrading from 0.6 to 0.8 in [`jaffi`](https://github.com/bluejekyll/jaffi/pull/17) and noticed that `impl Display` was removed in #47.

> Additionally, the Display trait is no longer implemented by these types - however I'm open to adding that back if there is demand for it.

So I re-added it as it's used for the method name generation. [This is an example of the name generation](https://github.com/simlay/jaffi/blob/8c57f0b8ead3926f468503818e3cebb4fabb348b/integration_tests/src/lib.rs#L124-L126). If I use the `Debug` representation it's pretty gross (and would also be a breaking change).