### PR TITLE
Fix clippy lints and update checkout action

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Get latest stable Rust
         run: rustup toolchain install stable --profile default
       - name: Check out source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Check formatting
         run: cargo fmt -v -- --check
   clippy:
@@ -26,6 +26,6 @@ jobs:
       - name: Get clippy
         run: rustup component add clippy
       - name: Check out source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Check clippy lints
         run: cargo clippy --all --no-deps

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Get latest stable Rust
         run: rustup toolchain install stable --profile minimal
       - name: Check out source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Run tests
         run: cargo test --all
   beta:
@@ -24,7 +24,7 @@ jobs:
       - name: Get latest beta Rust
         run: rustup toolchain install beta --profile minimal
       - name: Check out source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Check compilation
         run: cargo check
   nightly:
@@ -34,6 +34,6 @@ jobs:
       - name: Get latest nightly Rust
         run: rustup toolchain install nightly --profile minimal
       - name: Check out source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Check compilation
         run: cargo check

--- a/src/descriptors.rs
+++ b/src/descriptors.rs
@@ -42,7 +42,7 @@ pub struct ClassName<'a> {
     pub segments: Vec<UnqualifiedSegment<'a>>,
 }
 
-impl<'a> ClassName<'a> {
+impl ClassName<'_> {
     fn byte_len(&self) -> usize {
         self.segments
             .iter()
@@ -87,7 +87,7 @@ pub enum FieldType<'a> {
     Object(ClassName<'a>),
 }
 
-impl<'a> FieldType<'a> {
+impl FieldType<'_> {
     fn byte_len(&self) -> usize {
         match self {
             FieldType::Object(class_name) => 1 + class_name.byte_len(),
@@ -102,7 +102,7 @@ pub struct FieldDescriptor<'a> {
     pub field_type: FieldType<'a>,
 }
 
-impl<'a> FieldDescriptor<'a> {
+impl FieldDescriptor<'_> {
     fn byte_len(&self) -> usize {
         (self.dimensions as usize) + self.field_type.byte_len()
     }
@@ -149,7 +149,7 @@ pub enum ReturnDescriptor<'a> {
     Void,
 }
 
-impl<'a> ReturnDescriptor<'a> {
+impl ReturnDescriptor<'_> {
     fn byte_len(&self) -> usize {
         match self {
             Self::Return(d) => d.byte_len(),
@@ -177,7 +177,7 @@ pub struct MethodDescriptor<'a> {
     pub return_type: ReturnDescriptor<'a>,
 }
 
-impl<'a> MethodDescriptor<'a> {
+impl MethodDescriptor<'_> {
     fn byte_len(&self) -> usize {
         1 + self
             .parameters
@@ -217,7 +217,7 @@ pub(crate) fn parse_method_descriptor<'a>(
 pub(crate) fn parse_array_descriptor<'a>(
     data: &Cow<'a, str>,
 ) -> Result<Option<FieldDescriptor<'a>>, ParseError> {
-    if data.len() == 0 || data.as_bytes()[0] != b'[' {
+    if data.is_empty() || data.as_bytes()[0] != b'[' {
         return Ok(None);
     }
     let desc = parse_field_descriptor(data, 0)?;


### PR DESCRIPTION
Over in #54 I saw that CI was gonna fail due to new clippy lints. I think I fixed the ones that will fail over there but figured I should just make it a separate PR.

Also, I ran [`actionlint`](https://github.com/rhysd/actionlint) and saw that some of the checkout actions were out of date so I updated those.